### PR TITLE
Add administrator info to conversation members

### DIFF
--- a/src/app/home/conversation/conversation.component.ts
+++ b/src/app/home/conversation/conversation.component.ts
@@ -14,6 +14,7 @@ import {
   transition,
 } from '@angular/animations';
 import { Conversation } from '../../shared/model/conversation';
+import { AuthService } from '../../shared/data-access/auth.service';
 
 @Component({
   standalone: true,
@@ -48,6 +49,7 @@ import { Conversation } from '../../shared/model/conversation';
       @if (showSettings) {
       <app-conversation-settings
         [conversation]="conversationService.currentConversation()!"
+        [admin]="isAdmin()"
         [@inOutAnimation]
         (removeMember)="removeMember($event)"
       ></app-conversation-settings>
@@ -76,6 +78,7 @@ import { Conversation } from '../../shared/model/conversation';
 export default class ConversationComponent {
   conversationService = inject(ConversationService);
   messageService = inject(MessageService);
+  authService = inject(AuthService);
 
   showSettings: boolean = false;
 
@@ -91,5 +94,14 @@ export default class ConversationComponent {
     );
 
     this.conversationService.update$.next(conversation);
+  }
+
+  isAdmin(): boolean {
+    return this.conversationService
+      .currentConversation()
+      ?.members?.filter((m) => m.uid === this.authService.user()?.uid)
+      .find((m) => m.admin)
+      ? true
+      : false;
   }
 }

--- a/src/app/home/conversation/ui/conversation-settings.component.ts
+++ b/src/app/home/conversation/ui/conversation-settings.component.ts
@@ -22,10 +22,24 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog.compon
         @for(member of conversation.members; track member.uid) {
         <li class="p-2 w-full rounded flex gap-3 items-center">
           <app-avatar [imgUrls]="[member.imgUrl]" size="s"></app-avatar>
-          <span>{{ member.username }}</span>
-          <button class="ml-auto flex items-center justify-center p-1 rounded-full cursor-pointer hover:bg-gray-200" (click)="openRemoveMemberConfirmDialog(); memberToBeRemoved = member.uid">
-            <mat-icon class="material-icons-outlined font-thin scale-75">person_remove</mat-icon>
+          <div class="flex flex-col">
+            <span>{{ member.username }}</span>
+            @if(member.admin) {
+            <span class="text-xs text-gray-400">Administrator</span>
+            }
+          </div>
+          @if (admin) {
+          <button
+            class="ml-auto flex items-center justify-center p-1 rounded-full cursor-pointer hover:bg-gray-200"
+            (click)="
+              openRemoveMemberConfirmDialog(); memberToBeRemoved = member.uid
+            "
+          >
+            <mat-icon class="material-icons-outlined font-thin scale-75"
+              >person_remove</mat-icon
+            >
           </button>
+          }
         </li>
         }
       </ul>
@@ -35,6 +49,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog.compon
 })
 export class ConversationSettingsComponent {
   @Input({ required: true }) conversation!: Conversation;
+  @Input({ required: true }) admin!: boolean;
   @Output() removeMember: EventEmitter<string> = new EventEmitter<string>();
 
   constructor(public dialog: MatDialog) {}
@@ -48,10 +63,10 @@ export class ConversationSettingsComponent {
       exitAnimationDuration: 120,
       data: {
         message: 'Are You sure You want to remove the member?',
-      }
+      },
     });
 
-    dialogRef.afterClosed().subscribe(result => {
+    dialogRef.afterClosed().subscribe((result) => {
       if (!result.data) {
         return;
       }
@@ -59,6 +74,6 @@ export class ConversationSettingsComponent {
         this.removeMember.emit(this.memberToBeRemoved);
         this.memberToBeRemoved = undefined;
       }
-    })
+    });
   }
 }

--- a/src/app/home/ui/users-search-modal.component.ts
+++ b/src/app/home/ui/users-search-modal.component.ts
@@ -15,7 +15,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { UserService } from '../../shared/data-access/user.service';
 import { MatChipsModule } from '@angular/material/chips';
-import { UserDetails } from '../../shared/model/user';
+import { Member, UserDetails } from '../../shared/model/user';
 import { MatIconModule } from '@angular/material/icon';
 import {
   MatAutocompleteModule,
@@ -150,7 +150,8 @@ export class UsersSearchModalComponent {
       name: this.nameFormControl.getRawValue(),
       type: this.members.length < 2 ? 'PRIVATE' : 'GROUP',
       memberIds: [...memberUids, this.authService.user()!.uid],
-      members: [...this.members, this.authService.userDetails()!],
+
+      members: [...this.members, { ...this.authService.userDetails()!, admin: true}],
     };
     this.conversationService.add$.next(newConversation);
     this.dialogRef.close();

--- a/src/app/shared/model/conversation.ts
+++ b/src/app/shared/model/conversation.ts
@@ -1,11 +1,11 @@
-import { UserDetails } from "./user";
+import { Member, UserDetails } from "./user";
 
 export interface Conversation {
     uid: string;
     name: string;
     type?: 'PRIVATE' | 'GROUP';
     memberIds?: string[];
-    members?: UserDetails[];
+    members?: Member[];
     created?: string;
     updated?: string;
     createdBy?: string;
@@ -17,5 +17,5 @@ export interface CreateConversation {
     name: string;
     type: 'PRIVATE' | 'GROUP';
     memberIds: string[];
-    members: UserDetails[];
+    members: Member[];
 }

--- a/src/app/shared/model/user.ts
+++ b/src/app/shared/model/user.ts
@@ -9,3 +9,11 @@ export interface UserDetails {
     email: string;
     imgUrl: string;
 }
+
+export interface Member {
+    uid: string;
+    username: string;
+    email: string;
+    imgUrl: string;
+    admin?: boolean;
+}


### PR DESCRIPTION
Added info if the the member of a conversation is an admin For now only the creator is set to be an admin, set on client site on conversation creation. Cloud function to be considered Only conversation's admin is able to edit(remove) members of a conversation Todo: firebase rule to check if a user is really an admin